### PR TITLE
Update augment branch to use kernels for zero-fill before layernorm and rmsnorm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,19 @@ def te_version() -> str:
     with open(root_path / "VERSION", "r") as f:
         version = f.readline().strip()
 
+    try:
+        output = subprocess.run(
+            ["git", "rev-parse" , "--short", "HEAD"],
+            capture_output=True,
+            cwd=root_path,
+            check=True,
+            universal_newlines=True,
+        )
+    except (CalledProcessError, OSError):
+        commit = ""
+    else:
+        commit = output.stdout.strip()
+
     # [augment] Here is where we replace the git hash with our own versioning.
     # You can disable this behavior with NVTE_NO_AUGMENT_VERSION=1.
     if not int(os.getenv("NVTE_NO_AUGMENT_VERSION", "0")):
@@ -43,21 +56,10 @@ def te_version() -> str:
         torch_version = parse(torch.__version__)
         cuda_version = parse(torch.version.cuda)
         version_string = f".cu{cuda_version.major}{cuda_version.minor}.torch{torch_version.major}{torch_version.minor}"
-        return version + "+augment" + version_string
+        return version + "+augment" + version_string + "." + commit
 
     if not int(os.getenv("NVTE_NO_LOCAL_VERSION", "0")):
-        try:
-            output = subprocess.run(
-                ["git", "rev-parse" , "--short", "HEAD"],
-                capture_output=True,
-                cwd=root_path,
-                check=True,
-                universal_newlines=True,
-            )
-        except (CalledProcessError, OSError):
-            pass
-        else:
-            commit = output.stdout.strip()
+        if len(commit) > 0:
             version += f"+{commit}"
     return version
 

--- a/transformer_engine/common/layer_norm/ln_api.cpp
+++ b/transformer_engine/common/layer_norm/ln_api.cpp
@@ -237,6 +237,8 @@ void layernorm_fwd(const Tensor& x,        // BxSxhidden_size
         params.barrier = reinterpret_cast<int*>(barrier->data.dptr);
     }
 
+    // NOTE[augment]: this envvar exists to restore the prior behavior of TE (ie, use a memset
+    // kernel. So if you want to get the upstream behavior, run with NVTE_FORCE_MEMSET=1.
     const char *envval = std::getenv("NVTE_FORCE_MEMSET");
     bool force_memset = (envval != nullptr) && (std::string(envval) == "1");
     // Clear buffers

--- a/transformer_engine/common/rmsnorm/rmsnorm_api.cpp
+++ b/transformer_engine/common/rmsnorm/rmsnorm_api.cpp
@@ -182,6 +182,8 @@ void rmsnorm_fwd(const Tensor &x, const Tensor &gamma, const float epsilon, Tens
         params.barrier = reinterpret_cast<int *>(barrier->data.dptr);
     }
 
+    // NOTE[augment]: this envvar exists to restore the prior behavior of TE (ie, use a memset
+    // kernel. So if you want to get the upstream behavior, run with NVTE_FORCE_MEMSET=1.
     const char *envval = std::getenv("NVTE_FORCE_MEMSET");
     bool force_memset = (envval != nullptr) && (std::string(envval) == "1");
     // Clear buffers


### PR DESCRIPTION
This PR updates the TE code to use a fill kernel (not memset) to zero-out buffers before calling the fast fp8 layernorm and rmsnorm kernels. We are making this change because the memset ops introduce gaps in cuda graph execution.